### PR TITLE
theme: rough-port of the textmate grammars to prism.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,7 +2,7 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 
 const lightCodeTheme = require('prism-react-renderer/themes/github');
-const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const darkCodeTheme = require('prism-react-renderer/themes/okaidia');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,24 @@
+import siteConfig from '@generated/docusaurus.config';
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: {prism},
+  } = siteConfig;
+  const {additionalLanguages} = prism;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
+  additionalLanguages.forEach((lang) => {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
+
+  require('./prism-opengoal.js');
+  require('./prism-opengoal_goos.js');
+  require('./prism-opengoal_ir.js');
+
+  delete globalThis.Prism;
+}

--- a/src/theme/prism-opengoal.js
+++ b/src/theme/prism-opengoal.js
@@ -1,0 +1,82 @@
+// TODO - quoted expressions
+// TODO - proper sexpr
+Prism.languages.opengoal = {
+	'comment': [
+		{
+			pattern: /#\|[\s\S]*?(?:\|#|$)/,
+			lookbehind: true,
+			greedy: true
+		},
+		{
+			pattern: /(^|[^\\:]);+.*/,
+			lookbehind: true,
+			greedy: true
+		}
+	],
+  'string': {
+		pattern: /"(?:[^"\\]|\\.)*"/,
+		greedy: true
+	},
+  'keyword': {
+		pattern: /de[sf][\w\d._:+=><!?*-]*/,
+		lookbehind: true
+	},
+  'function': {
+		pattern: /((?:^|[^'])\()[\w*+!?'<>=/.-]+(?=[\s)]|$)/,
+		lookbehind: true
+	},
+  'constant': [
+    // nil
+    {
+      pattern: /(none)(?=\s|\)|\]|\})/,
+      greedy: true
+    }
+  ],
+  'boolean': [
+    // true/false,
+    {
+      pattern: /(#t|#f)/,
+      greedy: true
+    }
+  ],
+  'number': [
+    // ratio
+    {
+      pattern: /([-+]?\d+\/\d+)/,
+      greedy: true
+    },
+    // hex
+    {
+      pattern: /([-+]?#[0-9a-fA-F]+N?)/,
+      greedy: true
+    },
+    // binary
+    {
+      pattern: /([-+]?#b[0-9a-fA-F]+N?)/,
+      greedy: true
+    },
+    // floats
+    {
+      pattern: /([-+]?[0-9]+(?:(\.|(?=[eEM]))[0-9]*([eE][-+]?[0-9]+)?)M?)/,
+      greedy: true
+    },
+    // integers
+    {
+      pattern: /\s([-+]?\d+N?)/,
+      greedy: true
+    }
+  ],
+  'property': [
+    // keyword
+    {
+      pattern: /(\s|\(|\[|\{):[\w\#\.\-\_\:\+\=\>\<\/\!\?\*]+(?=(\s|\)|\]|\}|\,))/,
+      lookbehind: true
+    }
+  ],
+  'operator': [
+    // reader macros
+    {
+      pattern: /('|,@|`|,|&->)/
+    }
+  ]
+};

--- a/src/theme/prism-opengoal_goos.js
+++ b/src/theme/prism-opengoal_goos.js
@@ -1,0 +1,81 @@
+// TODO - quoted expressions
+Prism.languages.opengoal_goos = {
+	'comment': [
+		{
+			pattern: /#\|[\s\S]*?(?:\|#|$)/,
+			lookbehind: true,
+			greedy: true
+		},
+		{
+			pattern: /(^|[^\\:]);+.*/,
+			lookbehind: true,
+			greedy: true
+		}
+	],
+  'string': {
+		pattern: /"(?:[^"\\]|\\.)*"/,
+		greedy: true
+	},
+  'keyword': {
+		pattern: /de[sf][\w\d._:+=><!?*-]*/,
+		lookbehind: true
+	},
+  'function': {
+		pattern: /((?:^|[^'])\()[\w*+!?'<>=/.-]+(?=[\s)]|$)/,
+		lookbehind: true
+	},
+  'constant': [
+    // nil
+    {
+      pattern: /(none)(?=\s|\)|\]|\})/,
+      greedy: true
+    }
+  ],
+  'boolean': [
+    // true/false,
+    {
+      pattern: /(#t|#f)/,
+      greedy: true
+    }
+  ],
+  'number': [
+    // ratio
+    {
+      pattern: /([-+]?\d+\/\d+)/,
+      greedy: true
+    },
+    // hex
+    {
+      pattern: /([-+]?#[0-9a-fA-F]+N?)/,
+      greedy: true
+    },
+    // binary
+    {
+      pattern: /([-+]?#b[0-9a-fA-F]+N?)/,
+      greedy: true
+    },
+    // floats
+    {
+      pattern: /([-+]?[0-9]+(?:(\.|(?=[eEM]))[0-9]*([eE][-+]?[0-9]+)?)M?)/,
+      greedy: true
+    },
+    // integers
+    {
+      pattern: /\s([-+]?\d+N?)/,
+      greedy: true
+    }
+  ],
+  'property': [
+    // keyword
+    {
+      pattern: /(\s|\(|\[|\{):[\w\#\.\-\_\:\+\=\>\<\/\!\?\*]+(?=(\s|\)|\]|\}|\,))/,
+      lookbehind: true
+    }
+  ],
+  'operator': [
+    // reader macros
+    {
+      pattern: /('|,@|`|,|&->)/
+    }
+  ]
+};

--- a/src/theme/prism-opengoal_ir.js
+++ b/src/theme/prism-opengoal_ir.js
@@ -1,0 +1,61 @@
+// TODO - embeded opengoal
+// TODO - registers and CSS rules to make it look nice
+// TODO - op numbers
+// TODO - mnemonic styling
+Prism.languages.opengoal_ir = {
+  'string': {
+		pattern: /"(?:[^"\\]|\\.)*"/,
+		greedy: true
+	},
+  'function': [
+    // function names
+    {
+      pattern: /;\s\.function\s(.*)/
+    },
+    // mnemonics
+    {
+      pattern: /^\s+\b([\w\.]+)\b/,
+      greedy: true
+    }
+  ],
+  'comment': [
+		{
+			pattern: /;+.*/,
+		}
+	],
+  'property': [
+    // function calls
+    {
+      pattern: /s7,\s[\w-!\*]+/,
+      greedy: true
+    },
+    {
+      pattern: /([\w-!\*]+)(?:\(s7\))/,
+      greedy: true
+    },
+    {
+      pattern: /\bt9/
+    }
+  ],
+  'builtin': [
+    {
+      pattern: /[BL]\d+:?/
+    }
+  ],
+  'keyword': {
+		pattern: /[astv][0-3](?:-\d+)?/,
+		lookbehind: true
+	},
+  'number': [
+    // op number
+    {
+      pattern: /(?:;; )\[([\s\d]+)\]/,
+      greedy: true
+    },
+    // immediates
+    {
+      pattern: /\b(\d+)|r0/,
+      greedy: true
+    }
+  ],
+};


### PR DESCRIPTION
These aren't yet perfect, but I won't likely spend much time on these compared to what was spent on the textmate grammars.  This is only for documentation so a bit of color goes a long way.

- `opengoal[-ir|-goos]` is the syntax name to use in code-blocks

Closes #57 