### PR TITLE
docs: update allowed characters for jak 1

### DIFF
--- a/documentation/contributing/text-translations.md
+++ b/documentation/contributing/text-translations.md
@@ -45,10 +45,10 @@ Jak 1's font supports the following characters from a translation string:
 - 0-9
 - Space
 - The following ASCII special characters
-  - `' ! ( ) + - , . / : = < > *`
+  - `' ! ( ) + - , . / : = < > * % ? "`
   - `<TIL>` Represents `~`
 - Other Special Characters
-  - ``ˇ ` ¨ º ¡ ¿ Æ Ç ß ™ 、``
+  - ``ˇ ` ¨ º ¡ ¿ Æ Ç ß ™ 、Å Ø``
 - Accents
   - Tildes
     - `Ñ Ã Õ`


### PR DESCRIPTION
Added support for `Ø` and there were a few already supported characters that were missing from the documentation