### PR TITLE
Better pagination options on decomp pages

### DIFF
--- a/src/pages/progress/jak1.js
+++ b/src/pages/progress/jak1.js
@@ -456,6 +456,7 @@ export default function Jak1DecompProgress() {
                       exportButton: true,
                       sorting: true,
                       pageSize: 25,
+                      pageSizeOptions:[25, 50, 100],
                     }}
                     isLoading={false}
                   />

--- a/src/pages/progress/jak2.js
+++ b/src/pages/progress/jak2.js
@@ -449,6 +449,7 @@ export default function Jak2DecompProgress() {
                       exportButton: true,
                       sorting: true,
                       pageSize: 25,
+                      pageSizeOptions:[25, 50, 100],
                     }}
                     isLoading={false}
                   />

--- a/src/pages/progress/jak3.js
+++ b/src/pages/progress/jak3.js
@@ -449,6 +449,7 @@ export default function Jak3DecompProgress() {
                       exportButton: true,
                       sorting: true,
                       pageSize: 25,
+                      pageSizeOptions:[25, 50, 100],
                     }}
                     isLoading={false}
                   />


### PR DESCRIPTION
The current defaults are kind of silly for 1000s of rows, and the "25" option it wakes up with isn't even present 😅 

before
![image](https://github.com/open-goal/open-goal.github.io/assets/2515356/f2a14f01-d22c-4561-9b0e-89732b0fb7f3)

after 
![image](https://github.com/open-goal/open-goal.github.io/assets/2515356/c7f7ee6c-a382-4522-a3ab-4e579e0a8867)
