### PR TITLE
frontend: disable SVG optimization again

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -207,6 +207,7 @@ function customizedSvgo() {
                 ) {
                   if (typeof loader.options === "object") {
                     loader.options.svgoConfig = null;
+                    loader.options.svgo = false;
                   }
                 }
               }


### PR DESCRIPTION
See:
- https://github.com/facebook/docusaurus/issues/8297
- https://github.com/facebook/docusaurus/issues/9192

SVG optimization does not account for global state, it minifies each SVG in a local context.  This leads to problems.  This was hacked around before but a new `svgo: true` config option has appeared that had to be disabled as well.

9192 on docusaurus should make this possible without a webpack injection.