### PR TITLE
Update "When is Jak 3" in faq.mdx

### DIFF
--- a/documentation/faq.mdx
+++ b/documentation/faq.mdx
@@ -56,7 +56,7 @@ _Jak and Daxter: The Precursor Legacy_ and _Jak II_ are at a stage where they ar
 
 Please remember that we do this work for free, in our spare time, when we feel like it. There are no rigid timelines that we make for ourselves, things will be done when they are done.
 
-- _Jak 3_ is in early stages, do not hold your breath on this being complete within atleast a year.
+- _Jak 3_ has been fully decompiled, but still requires many bug fixes before it is playable. It is hard to estimate how long it takes to fix these bugs, so it may take several months. As usual, we will inform everyone when it is playable in the monthly blog.
 - As of now, it's unsure whether _Jak X_ will be decompiled.
 <!-- https://discord.com/channels/756287461377703987/1009521377113555014/1228907276052594718 -->
 <!-- https://discord.com/channels/756287461377703987/1094315000308437162/1225126287870398598 -->


### PR DESCRIPTION
Impatient/eager fans seem to think the FAQ is outdated, so I updated the prospects of Jak 3, trying to avoid time-based promises.

Recently:
https://discord.com/channels/756287461377703987/1284560903324565555/1284562458148732938