### PR TITLE
downloads: fix linux download being suggested for macOS

### DIFF
--- a/src/components/LauncherDownloadLink/index.js
+++ b/src/components/LauncherDownloadLink/index.js
@@ -30,7 +30,7 @@ export default function LauncherDownloadLink({ hideTutorial = false }) {
       `${parser.getOS().name} - ${parser.getCPU().architecture}`,
     );
     const isWindows = platformLower === "windows";
-    const isMacOS = platformLower === "mac os";
+    const isMacOS = platformLower === "mac os" || platformLower === "macos";
     const isLinux = !isWindows && !isMacOS;
     const isARM =
       parser.getCPU().architecture === "arm" ||

--- a/src/components/SplitButton/index.js
+++ b/src/components/SplitButton/index.js
@@ -75,7 +75,6 @@ export default function SplitButton({
         }}
       >
         {secondaryButtonLabels.map((option, index) => {
-          console.log(`${primaryButtonUrl} === ${secondaryButtonUrls[index]}`);
           if (secondaryButtonUrls[index] === primaryButtonUrl) {
             return null;
           }


### PR DESCRIPTION
Showing ARM or not depends entirely on the user-agent that is provided by the browser, there's no guarantee that it will be possible to discern it.